### PR TITLE
Add ingest Lambda and S3 trigger

### DIFF
--- a/lambda_functions/ingest_study_material.py
+++ b/lambda_functions/ingest_study_material.py
@@ -1,0 +1,71 @@
+import json
+import os
+import io
+from datetime import datetime
+
+import boto3
+import fitz  # PyMuPDF
+import docx
+from opensearchpy import OpenSearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
+
+
+def handler(event, context):
+    """Process uploaded study material, generate embeddings and store them."""
+    # Extract bucket and object key from the S3 event
+    record = event['Records'][0]
+    bucket = record['s3']['bucket']['name']
+    key = record['s3']['object']['key']
+
+    s3 = boto3.client('s3')
+    resp = s3.get_object(Bucket=bucket, Key=key)
+    body = resp['Body'].read()
+
+    text = ''
+    if key.lower().endswith('.pdf'):
+        doc = fitz.open(stream=body, filetype='pdf')
+        for page in doc:
+            text += page.get_text()
+    elif key.lower().endswith('.docx'):
+        document = docx.Document(io.BytesIO(body))
+        text = '\n'.join(p.text for p in document.paragraphs)
+    else:
+        print('Unsupported file type: %s', key)
+        return {'statusCode': 400, 'body': 'Unsupported file type'}
+
+    tokens = text.split()
+    chunk_size = 500
+    chunks = [' '.join(tokens[i:i + chunk_size]) for i in range(0, len(tokens), chunk_size)]
+
+    bedrock = boto3.client('bedrock-runtime')
+    region = os.environ.get('AWS_REGION', 'us-east-1')
+
+    creds = boto3.Session().get_credentials()
+    awsauth = AWS4Auth(creds.access_key, creds.secret_key, region, 'aoss', session_token=creds.token)
+    opensearch = OpenSearch(
+        hosts=[{'host': os.environ['OPENSEARCH_ENDPOINT'], 'port': 443}],
+        http_auth=awsauth,
+        use_ssl=True,
+        verify_certs=True,
+        connection_class=RequestsHttpConnection,
+    )
+
+    for idx, chunk in enumerate(chunks):
+        resp = bedrock.invoke_model(
+            modelId='amazon.titan-embed-text-v1',
+            body=json.dumps({'inputText': chunk})
+        )
+        payload = json.loads(resp['body'].read())
+        embedding = payload['embedding']
+
+        document = {
+            'id': f'{key}-{idx}',
+            'text': chunk,
+            'source': key,
+            'timestamp': datetime.utcnow().isoformat(),
+            'embedding': embedding,
+        }
+
+        opensearch.index(index='cert-embeddings', body=document, id=document['id'])
+
+    return {'statusCode': 200, 'body': 'Processed'}

--- a/newcdkproject/newcdkproject_stack.py
+++ b/newcdkproject/newcdkproject_stack.py
@@ -8,8 +8,14 @@ future Lambda functions that will interact with these services.
 
 from aws_cdk import (
     Stack,
+    Duration,
+    RemovalPolicy,
     aws_s3 as s3,
     aws_opensearchserverless as oss,
+    aws_lambda as _lambda,
+    aws_events as events,
+    aws_events_targets as targets,
+    aws_logs as logs,
     aws_iam as iam,
 )
 import json
@@ -43,6 +49,20 @@ class NewcdkprojectStack(Stack):
 
         # Allow read-only access to the S3 bucket
         bucket.grant_read(lambda_role)
+
+        # Additional permissions for OpenSearch and Bedrock
+        lambda_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["aoss:APIAccessAll"],
+                resources=["*"]
+            )
+        )
+        lambda_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["bedrock:InvokeModel"],
+                resources=["arn:aws:bedrock:*::foundation-model/amazon.titan-embed-text-v1"],
+            )
+        )
 
         # ------------------------------------------------------------------
         # 3. OpenSearch Serverless collection for RAG embeddings
@@ -139,15 +159,56 @@ class NewcdkprojectStack(Stack):
         access_policy.add_dependency(collection)
 
         # ------------------------------------------------------------------
+        # 4. Lambda function to ingest study materials
+        # ------------------------------------------------------------------
+        ingest_lambda = _lambda.Function(
+            self,
+            "IngestStudyMaterialFunction",
+            runtime=_lambda.Runtime.PYTHON_3_11,
+            handler="ingest_study_material.handler",
+            code=_lambda.Code.from_asset("lambda_functions"),
+            timeout=Duration.seconds(60),
+            memory_size=512,
+            role=lambda_role,
+            function_name="IngestStudyMaterialFunction",
+        )
+
+        log_group = logs.LogGroup(
+            self,
+            "IngestStudyMaterialLogGroup",
+            log_group_name=f"/aws/lambda/{ingest_lambda.function_name}",
+            removal_policy=RemovalPolicy.DESTROY,
+        )
+
+        # EventBridge rule for S3 uploads
+        rule = events.Rule(
+            self,
+            "S3IngestRule",
+            event_pattern=events.EventPattern(
+                source=["aws.s3"],
+                detail_type=["Object Created"],
+                detail={"bucket": {"name": [bucket.bucket_name]}},
+            ),
+        )
+
+        rule.add_target(targets.LambdaFunction(ingest_lambda))
+
+        # ------------------------------------------------------------------
         # Outputs for easy reference
         # ------------------------------------------------------------------
         self.bucket_name = bucket.bucket_name
         self.collection_name = collection.name
         self.lambda_role_arn = lambda_role.role_arn
+        self.ingest_lambda_name = ingest_lambda.function_name
+        self.log_group_name = log_group.log_group_name
+        self.s3_rule_name = rule.rule_name
 
         self.add_output("BucketName", self.bucket_name)
         self.add_output("CollectionName", self.collection_name)
         self.add_output("LambdaRoleArn", self.lambda_role_arn)
+        self.add_output("IngestLambdaName", self.ingest_lambda_name)
+        self.add_output("IngestLambdaLogGroup", self.log_group_name)
+        self.add_output("S3EventRule", self.s3_rule_name)
 
     # Helper to add outputs with consistent naming
     def add_output(self, id_: str, value: str) -> None:


### PR DESCRIPTION
## Summary
- add `IngestStudyMaterialFunction` lambda for processing uploaded files
- grant permissions for Bedrock and OpenSearch
- create EventBridge rule for S3 uploads
- output lambda and log group names

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438e7a1be8833180a90d36958986dc