### PR TITLE
Add chatbot query API

### DIFF
--- a/lambda_functions/chatbot_query.py
+++ b/lambda_functions/chatbot_query.py
@@ -1,0 +1,65 @@
+import json
+import os
+
+import boto3
+import requests
+from requests_aws4auth import AWS4Auth
+
+bedrock = boto3.client("bedrock-runtime")
+region = boto3.Session().region_name
+credentials = boto3.Session().get_credentials()
+auth = AWS4Auth(credentials.access_key, credentials.secret_key, region, "aoss", session_token=credentials.token)
+
+OPENSEARCH_ENDPOINT = os.environ.get("OPENSEARCH_ENDPOINT")
+INDEX_NAME = "cert-embeddings"
+
+
+def embed_text(text: str) -> list:
+    body = json.dumps({"inputText": text})
+    response = bedrock.invoke_model(modelId="amazon.titan-embed-text-v1", body=body)
+    payload = json.loads(response["body"].read())
+    return payload.get("embedding")
+
+
+def search_embeddings(vector: list) -> list:
+    url = f"https://{OPENSEARCH_ENDPOINT}/{INDEX_NAME}/_search"
+    headers = {"Content-Type": "application/json"}
+    query = {
+        "size": 5,
+        "query": {"knn": {"vector": {"vector": vector, "k": 5}}},
+        "_source": ["text"],
+    }
+    r = requests.get(url, auth=auth, headers=headers, data=json.dumps(query))
+    r.raise_for_status()
+    hits = r.json().get("hits", {}).get("hits", [])
+    return [hit.get("_source", {}).get("text", "") for hit in hits]
+
+
+def generate_answer(question: str, context: str) -> str:
+    prompt = f"\n\n{context}\n\nQuestion: {question}\nAnswer:"
+    body = json.dumps({"prompt": prompt, "max_tokens_to_sample": 200})
+    response = bedrock.invoke_model(modelId="anthropic.claude-v2", body=body)
+    payload = json.loads(response["body"].read())
+    return payload.get("completion", "")
+
+
+def handler(event, context):
+    try:
+        body = json.loads(event.get("body", "{}"))
+    except json.JSONDecodeError:
+        return {"statusCode": 400, "body": json.dumps({"error": "Invalid JSON"})}
+
+    query = body.get("query")
+    if not query:
+        return {"statusCode": 400, "body": json.dumps({"error": "Missing query"})}
+
+    embedding = embed_text(query)
+    chunks = search_embeddings(embedding)
+    context_str = "\n\n".join(chunks)
+    answer = generate_answer(query, context_str)
+
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({"answer": answer}),
+    }

--- a/lambda_functions/ingest_study_material.py
+++ b/lambda_functions/ingest_study_material.py
@@ -40,10 +40,11 @@ def embed_text(text: str) -> list:
     return payload.get("embedding")
 
 
-def index_embedding(id_: str, embedding: list):
+def index_embedding(id_: str, embedding: list, text: str) -> None:
+    """Store the extracted text and its embedding in OpenSearch."""
     url = f"https://{OPENSEARCH_ENDPOINT}/{INDEX_NAME}/_doc/{id_}"
     headers = {"Content-Type": "application/json"}
-    data = json.dumps({"vector": embedding})
+    data = json.dumps({"vector": embedding, "text": text})
     requests.put(url, auth=auth, headers=headers, data=data)
 
 
@@ -56,5 +57,5 @@ def handler(event, context):
             s3_client.download_file(bucket, key, tmp_path)
             text = extract_text(tmp_path)
             embedding = embed_text(text)
-            index_embedding(key, embedding)
+            index_embedding(key, embedding, text)
     return {"status": "processed", "records": len(event.get("Records", []))}


### PR DESCRIPTION
## Summary
- add text to OpenSearch index during ingest
- add ChatbotQueryFunction Lambda
- expose /ask POST endpoint via API Gateway

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446effdf7c8331888ff0778e22641f