### PR TITLE
Fix packaging for Chatbot lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ This project deploys AWS resources for a chatbot that indexes study material fro
    ```bash
    pip install -r requirements.txt -r requirements-dev.txt
    ```
-3. Build the Lambda layer containing third‑party packages. Dependencies are listed in `lambda_functions/requirements.txt`.
+3. Build the Lambda layer containing third‑party packages. Dependencies are
+   listed in `lambda_functions/requirements.txt`.
    ```bash
-   pip install -r lambda_functions/requirements.txt -t lambda_layer/python
+   ./build_layer.sh
    ```
 4. Synthesize the CloudFormation template and deploy.
    ```bash

--- a/README.md
+++ b/README.md
@@ -1,58 +1,32 @@
+# AI Certification Study Assistant
 
-# Welcome to your CDK Python project!
+This project deploys AWS resources for a chatbot that indexes study material from an S3 bucket and serves answers through an API Gateway endpoint. Embeddings are generated using Amazon Bedrock and stored in an OpenSearch Serverless collection.
 
-This is a blank project for CDK development with Python.
+## Setup
 
-The `cdk.json` file tells the CDK Toolkit how to execute your app.
+1. Create and activate a Python virtual environment.
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install the dependencies for the CDK app and tests.
+   ```bash
+   pip install -r requirements.txt -r requirements-dev.txt
+   ```
+3. Build the Lambda layer containing third‑party packages. Dependencies are listed in `lambda_functions/requirements.txt`.
+   ```bash
+   pip install -r lambda_functions/requirements.txt -t lambda_layer/python
+   ```
+4. Synthesize the CloudFormation template and deploy.
+   ```bash
+   cdk synth
+   cdk deploy
+   ```
 
-This project is set up like a standard Python project.  The initialization
-process also creates a virtualenv within this project, stored under the `.venv`
-directory.  To create the virtualenv it assumes that there is a `python3`
-(or `python` for Windows) executable in your path with access to the `venv`
-package. If for any reason the automatic creation of the virtualenv fails,
-you can create the virtualenv manually.
+After deployment, note the `ChatbotApiUrl` output. You can test the chatbot with:
 
-To manually create a virtualenv on MacOS and Linux:
-
+```bash
+curl -X POST <ChatbotApiUrl>ask \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What is IAM?"}'
 ```
-$ python -m venv .venv
-```
-
-After the init process completes and the virtualenv is created, you can use the following
-step to activate your virtualenv.
-
-```
-$ source .venv/bin/activate
-```
-
-If you are a Windows platform, you would activate the virtualenv like this:
-
-```
-% .venv\Scripts\activate.bat
-```
-
-Once the virtualenv is activated, you can install the required dependencies.
-
-```
-$ pip install -r requirements.txt
-```
-
-At this point you can now synthesize the CloudFormation template for this code.
-
-```
-$ cdk synth
-```
-
-To add additional dependencies, for example other CDK libraries, just add
-them to your `setup.py` file and rerun the `pip install -r requirements.txt`
-command.
-
-## Useful commands
-
- * `cdk ls`          list all stacks in the app
- * `cdk synth`       emits the synthesized CloudFormation template
- * `cdk deploy`      deploy this stack to your default AWS account/region
- * `cdk diff`        compare deployed stack with current state
- * `cdk docs`        open CDK documentation
-
-Enjoy!

--- a/build_layer.sh
+++ b/build_layer.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+mkdir -p lambda_layer/python
+pip install -r lambda_functions/requirements.txt -t lambda_layer/python

--- a/lambda_functions/ingest_study_material.py
+++ b/lambda_functions/ingest_study_material.py
@@ -40,9 +40,15 @@ def embed_text(text: str) -> list:
     return payload.get("embedding")
 
 
+def sanitize_id(id_: str) -> str:
+    """Make an S3 object key safe for use as a document ID."""
+    return id_.replace("/", "_")
+
+
 def index_embedding(id_: str, embedding: list, text: str) -> None:
     """Store the extracted text and its embedding in OpenSearch."""
-    url = f"https://{OPENSEARCH_ENDPOINT}/{INDEX_NAME}/_doc/{id_}"
+    safe_id = sanitize_id(id_)
+    url = f"https://{OPENSEARCH_ENDPOINT}/{INDEX_NAME}/_doc/{safe_id}"
     headers = {"Content-Type": "application/json"}
     data = json.dumps({"vector": embedding, "text": text})
     requests.put(url, auth=auth, headers=headers, data=data)

--- a/lambda_functions/requirements.txt
+++ b/lambda_functions/requirements.txt
@@ -1,0 +1,5 @@
+requests==2.31.0
+requests-aws4auth==1.2.3
+boto3==1.34.33
+PyPDF2==3.0.1
+python-docx==1.1.0

--- a/newcdkproject/newcdkproject_stack.py
+++ b/newcdkproject/newcdkproject_stack.py
@@ -17,7 +17,6 @@ from aws_cdk import (
     aws_apigateway as apigw,
     aws_s3_notifications as s3n,
 )
-from aws_cdk.aws_lambda_python_alpha import PythonFunction
 import json
 from constructs import Construct
 
@@ -188,13 +187,12 @@ class NewcdkprojectStack(Stack):
         # ------------------------------------------------------------------
         # Lambda function powering the chatbot API
         # ------------------------------------------------------------------
-        chatbot_lambda = PythonFunction(
+        chatbot_lambda = _lambda.Function(
             self,
             "ChatbotQueryFunction",
-            entry="lambda_functions",
             runtime=_lambda.Runtime.PYTHON_3_12,
-            index="chatbot_query.py",
-            handler="handler",
+            handler="chatbot_query.handler",
+            code=_lambda.Code.from_asset("lambda_functions"),
             role=lambda_role,
             timeout=Duration.seconds(30),
             memory_size=512,

--- a/newcdkproject/newcdkproject_stack.py
+++ b/newcdkproject/newcdkproject_stack.py
@@ -70,6 +70,17 @@ class NewcdkprojectStack(Stack):
         bucket.grant_read(lambda_role)
 
         # ------------------------------------------------------------------
+        # Lambda layer with third-party dependencies
+        # ------------------------------------------------------------------
+        dependencies_layer = _lambda.LayerVersion(
+            self,
+            "DependenciesLayer",
+            code=_lambda.Code.from_asset("lambda_layer"),
+            compatible_runtimes=[_lambda.Runtime.PYTHON_3_11, _lambda.Runtime.PYTHON_3_12],
+            description="Third-party libraries for study assistant",
+        )
+
+        # ------------------------------------------------------------------
         # ------------------------------------------------------------------
         # 3. OpenSearch Serverless collection for RAG embeddings
         # ------------------------------------------------------------------
@@ -174,6 +185,7 @@ class NewcdkprojectStack(Stack):
             handler="ingest_study_material.handler",
             code=_lambda.Code.from_asset("lambda_functions"),
             role=lambda_role,
+            layers=[dependencies_layer],
             environment={
                 "OPENSEARCH_ENDPOINT": collection.attr_collection_endpoint,
             },
@@ -194,6 +206,7 @@ class NewcdkprojectStack(Stack):
             handler="chatbot_query.handler",
             code=_lambda.Code.from_asset("lambda_functions"),
             role=lambda_role,
+            layers=[dependencies_layer],
             timeout=Duration.seconds(30),
             memory_size=512,
             environment={

--- a/newcdkproject/newcdkproject_stack.py
+++ b/newcdkproject/newcdkproject_stack.py
@@ -14,10 +14,10 @@ from aws_cdk import (
     aws_opensearchserverless as oss,
     aws_iam as iam,
     aws_lambda as _lambda,
-    aws_lambda_python_alpha as lambda_python,
     aws_apigateway as apigw,
     aws_s3_notifications as s3n,
 )
+from aws_cdk.aws_lambda_python_alpha import PythonFunction
 import json
 from constructs import Construct
 
@@ -188,7 +188,7 @@ class NewcdkprojectStack(Stack):
         # ------------------------------------------------------------------
         # Lambda function powering the chatbot API
         # ------------------------------------------------------------------
-        chatbot_lambda = lambda_python.PythonFunction(
+        chatbot_lambda = PythonFunction(
             self,
             "ChatbotQueryFunction",
             entry="lambda_functions",

--- a/newcdkproject/newcdkproject_stack.py
+++ b/newcdkproject/newcdkproject_stack.py
@@ -14,6 +14,7 @@ from aws_cdk import (
     aws_opensearchserverless as oss,
     aws_iam as iam,
     aws_lambda as _lambda,
+    aws_lambda_python_alpha as lambda_python,
     aws_apigateway as apigw,
     aws_s3_notifications as s3n,
 )
@@ -187,12 +188,13 @@ class NewcdkprojectStack(Stack):
         # ------------------------------------------------------------------
         # Lambda function powering the chatbot API
         # ------------------------------------------------------------------
-        chatbot_lambda = _lambda.Function(
+        chatbot_lambda = lambda_python.PythonFunction(
             self,
             "ChatbotQueryFunction",
+            entry="lambda_functions",
             runtime=_lambda.Runtime.PYTHON_3_12,
-            handler="chatbot_query.handler",
-            code=_lambda.Code.from_asset("lambda_functions"),
+            index="chatbot_query.py",
+            handler="handler",
             role=lambda_role,
             timeout=Duration.seconds(30),
             memory_size=512,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ python-docx==1.1.0
 boto3==1.34.33
 requests==2.31.0
 requests-aws4auth==1.2.3
-aws-cdk.aws-lambda-python-alpha==2.199.0a0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-docx==1.1.0
 boto3==1.34.33
 requests==2.31.0
 requests-aws4auth==1.2.3
+aws-cdk.aws-lambda-python-alpha==2.199.0a0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+import boto3
+
+# Ensure boto3 clients can be created without raising NoRegionError
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("AWS_SESSION_TOKEN", "test")
+
+boto3.setup_default_session()

--- a/tests/unit/test_ingest_utils.py
+++ b/tests/unit/test_ingest_utils.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_sanitize_id():
+    module = importlib.import_module("lambda_functions.ingest_study_material")
+    assert module.sanitize_id("folder/file.pdf") == "folder_file.pdf"

--- a/tests/unit/test_lambda_handlers.py
+++ b/tests/unit/test_lambda_handlers.py
@@ -1,0 +1,30 @@
+import json
+import importlib
+from unittest.mock import patch
+
+
+def test_chatbot_handler_success():
+    chatbot_query = importlib.import_module("lambda_functions.chatbot_query")
+    event = {"body": json.dumps({"query": "hi"})}
+    with patch.object(chatbot_query, "embed_text", return_value=[1.0]), \
+         patch.object(chatbot_query, "search_embeddings", return_value=["ctx"]), \
+         patch.object(chatbot_query, "generate_answer", return_value="answer"):
+        resp = chatbot_query.handler(event, None)
+    assert resp["statusCode"] == 200
+    assert json.loads(resp["body"]) == {"answer": "answer"}
+
+
+def test_ingest_handler_processes_record(tmp_path):
+    ingest_study_material = importlib.import_module("lambda_functions.ingest_study_material")
+    event = {"Records": [{"s3": {"bucket": {"name": "b"}, "object": {"key": "k"}}}]}
+    temp_dir = tmp_path
+    with patch.object(ingest_study_material, "s3_client") as mock_s3, \
+         patch.object(ingest_study_material, "extract_text", return_value="text"), \
+         patch.object(ingest_study_material, "embed_text", return_value=[0.1]), \
+         patch.object(ingest_study_material, "index_embedding") as mock_index, \
+         patch.object(ingest_study_material.tempfile, "TemporaryDirectory") as mock_tmp:
+        mock_tmp.return_value.__enter__.return_value = str(temp_dir)
+        resp = ingest_study_material.handler(event, None)
+    mock_s3.download_file.assert_called_once()
+    mock_index.assert_called_once()
+    assert resp["records"] == 1


### PR DESCRIPTION
## Summary
- bundle lambda dependencies for the chatbot function using `PythonFunction`
- include per-lambda requirements file
- add the PythonFunction alpha module to requirements

## Testing
- `pytest -q` *(fails: spawnSync docker ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68447640fbfc83318422c932b9a59625